### PR TITLE
Fix `undefined` results when total > participants

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function parse(data) {
 
 function select(list) {
   // If "total" is not specified on the options, it will retrieve the full list
-  var total = options.total || list.length;
+  var total = options.total < list.length ? options.total : list.length;
   return _.chain(list).shuffle().take(total).value();
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marmelada",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Randomly select people for FEMUG-SP meetings.",
   "license": "MIT",
   "repository": "rafaelrinaldi/marmelada",


### PR DESCRIPTION
Stop showing `undefined` attendees when there's less registers than requested.

# Before
![bug](https://cloud.githubusercontent.com/assets/24597/12838386/a7fe5c54-cbb4-11e5-80bf-798a4de423c3.gif)


# After
![fix](https://cloud.githubusercontent.com/assets/24597/12838388/ad66f91c-cbb4-11e5-9171-b0fe7d1c18d3.gif)
